### PR TITLE
Update yts_downloader.py

### DIFF
--- a/yts_downloader/yts_downloader.py
+++ b/yts_downloader/yts_downloader.py
@@ -13,14 +13,14 @@ def main():
     name = args.movie.lower()
 
     try:
-        r = requests.get('https://yts.lt/browse-movies', timeout=7)
+        r = requests.get('https://yts.lt/browse-movies', timeout=45)
     except requests.Timeout:
         print('Request timeout')
     else:
 
         soup = BeautifulSoup(r.text, 'html.parser')
         h2 = soup.find_all('h2')
-        movie_count = int((str(h2)[5:11].replace(',', '')))
+        movie_count = int((str(h2)[8:13].replace(',', '')))
         titles = []
         ids = []
         page = 1


### PR DESCRIPTION
On slower connections a 7 sec timeout is a very low threshold . I increased to 45. My 2020 MBP on 100/100 Mbps wifi was taking 25 seconds every time.

Also yts.am html has changed. They wrapped the value you're trying to get in <b>bold</b> tags. I updated line 23 to get the value needed. it was getting the first <b tag and the first 2 values of the number (<\b >18 ) and then trying to convert that to int.